### PR TITLE
fix: Save isp as category

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ module.exports = new BaseKonnector(async function fetch(fields) {
                 datetimeLabel: 'issueDate',
                 contentAuthor: 'bouygues',
                 subClassification: 'invoice',
-                categories: ['phone'],
+                categories: ['isp'],
                 issueDate: new Date(facture.dateFacturation),
                 invoiceNumber: facture.idFacture,
                 contractReference: compte.id,


### PR DESCRIPTION
This is necessary to differentiate phone bills and isp bills from bouygues files